### PR TITLE
Replaces peach with parallel

### DIFF
--- a/bunka.gemspec
+++ b/bunka.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chef', '~> 11.0'
   spec.add_dependency 'colorize'
   spec.add_dependency 'net-ssh'
-  spec.add_dependency 'peach'
+  spec.add_dependency 'parallel'
   spec.add_dependency 'thor'
 end

--- a/lib/bunka.rb
+++ b/lib/bunka.rb
@@ -1,4 +1,4 @@
-require 'peach'
+require 'parallel'
 
 require 'bunka/chef'
 require 'bunka/helpers'
@@ -15,7 +15,7 @@ class Bunka
       @verbose_success = verbose_success
       @invert = invert
 
-      knife_search(@query).peach(5) do |fqdn|
+      Parallel.map(knife_search(@query), in_threads: 15) do |fqdn|
         execute_query fqdn
       end
 


### PR DESCRIPTION
This practically doubles the speed.

`echo bunka` on 666 nodes:
1:57.69 with peach
1:06.74 with parallel

`md5sum /etc/debian_version ; sleep 2` on 57 nodes:
29.817 with peach
14.595 with parallel

![31264697](https://cloud.githubusercontent.com/assets/719108/4725581/d3d67532-595a-11e4-8020-c377e647faa1.jpg)
